### PR TITLE
feat: add version command and --version/-v flags to CLI

### DIFF
--- a/.github/issue_templates/bug_report.md
+++ b/.github/issue_templates/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Summary
+
+<!-- Brief description of the bug -->
+
+## Current Behavior
+
+<!-- What currently happens? -->
+
+## Expected Behavior
+
+<!-- What should happen instead? -->
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Context
+
+<!-- OS, browser, version, etc. -->
+
+## Technical Notes
+
+<!-- Optional: Any hints or pointers for implementation -->

--- a/.github/issue_templates/feature_request.md
+++ b/.github/issue_templates/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+labels: feature
+---
+
+## Summary
+
+<!-- Brief description of the feature -->
+
+## Context
+
+<!-- Why is this needed? What problem does it solve? -->
+
+## Expected Behavior
+
+<!-- How should this feature work? -->
+
+## Technical Notes
+
+<!-- Optional: Any hints or pointers for implementation -->
+
+## Resources
+
+<!-- Optional: Links to relevant docs, screenshots, or examples -->

--- a/.github/issue_templates/task.md
+++ b/.github/issue_templates/task.md
@@ -1,0 +1,27 @@
+---
+name: Task
+about: A general task or piece of work
+labels: task
+---
+
+## Summary
+
+<!-- What needs to be done? -->
+
+## Task Details
+
+<!-- What specifically needs to be done? -->
+- [ ] 
+- [ ] 
+
+## Context
+
+<!-- Optional: Why is this needed? Any background information? -->
+
+## Technical Notes
+
+<!-- Optional: Any hints or pointers for implementation -->
+
+## Resources
+
+<!-- Optional: Links to relevant docs, screenshots, or examples -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,78 @@
-## Summary
+<!-- Link to the issue this PR addresses -->
+Closes #
 
-<!-- Briefly describe what this PR changes and why. -->
+## Dependencies
 
-## Related Issue
+<!-- List any PRs that must be merged before this one -->
+<!--
+- #1234
+- _(none needed)_
+-->
 
-<!-- Link issue(s), e.g., Closes #123 -->
+## What does this PR do?
+
+<!-- Brief description of the change -->
 
 ## Type of Change
 
+<!-- Check one -->
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Refactor
-- [ ] Documentation update
-- [ ] Chore (build, CI, tooling, deps)
+- [ ] Documentation
 
-## Testing
+## What was changed
 
-<!-- Describe how this was tested (commands, environments, and key scenarios). -->
+<!-- Technical explanation for reviewers. Focus on important design decisions. -->
+
+## Changelog
+
+<!-- What should users see in the release notes? -->
+<!-- Examples:
+Feature: Users can now bulk archive items
+Bugfix: Fixed keyboard shortcut skipping extra frames
+None: not user visible
+-->
+
+
+## How to Test
+
+<!-- Describe how you tested your changes -->
+
+1.
+2.
+3.
+
+## How QA Should Test
+
+<!--
+Affected workflows:
+- Which user workflows does this change affect?
+
+Specific checks:
+- Step-by-step instructions for QA to verify the change
+-->
+
+## Rollback Plan
+
+<!-- What should be done if this causes problems in production? Examples:
+- Revert this PR
+- Remove feature flag "xyz" from all tenants
+- No rollback needed - totally safe change
+-->
 
 ## Checklist
 
-- [ ] I ran relevant tests locally.
-- [ ] I updated documentation (if needed).
-- [ ] I added/updated tests (if needed).
-- [ ] I checked for breaking changes.
+- [ ] My code follows the project style guidelines
+- [ ] Code passes linting and type checks
+- [ ] All tests pass
+- [ ] I have added tests for my changes (if applicable)
+- [ ] I have updated documentation (if applicable)
 
-## Screenshots / Recordings (if applicable)
+## Screenshots (if applicable)
 
-<!-- Add visual proof for UI changes. -->
+<!-- Add screenshots for UI changes -->
 
-## Breaking Changes
+## Note for Reviewer
 
-<!-- None or describe impact and migration steps. -->
+<!-- Any specific areas you want feedback on? -->

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Default vault path:
 
 - `~/.keycraft/vault.json`
 
-Override with `--vault` on commands.
+Override with `--vault` on commands, or set `KEYCRAFT_VAULT` for a default custom path.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ keycraft generate --length 32
 keycraft change-master
 keycraft backup
 keycraft audit --fail-on-issues
+keycraft version
 ```
 
 Default vault path:
@@ -61,6 +62,7 @@ Override with `--vault` on commands, or set `KEYCRAFT_VAULT` for a default custo
 - `change-master`: rotate master password and re-encrypt vault
 - `backup`: create timestamped encrypted backup of the vault file
 - `audit`: detect weak, reused, stale, duplicate, and malformed entries
+- `version`: print CLI version
 
 ## Additional examples
 

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	appName           = "keycraft"
+	appVersion        = "0.3.0"
 	vaultVersion      = 1
 	defaultIterations = 210_000
 	keyLength         = 32
@@ -104,6 +106,10 @@ func main() {
 	}
 
 	command := os.Args[1]
+	if command == "version" || command == "-v" || command == "--version" {
+		fmt.Println(versionString())
+		return
+	}
 	if command == "help" || command == "-h" || command == "--help" {
 		printUsage()
 		return
@@ -131,6 +137,9 @@ func main() {
 		err = runBackup(os.Args[2:])
 	case "audit":
 		err = runAudit(os.Args[2:])
+	case "version":
+		fmt.Println(versionString())
+		return
 	default:
 		printUsage()
 		err = fmt.Errorf("unknown command %q", command)
@@ -1456,6 +1465,10 @@ func cryptoRandInt(max int) (int, error) {
 	return int(n.Int64()), nil
 }
 
+func versionString() string {
+	return fmt.Sprintf("%s %s", appName, appVersion)
+}
+
 func printUsage() {
 	fmt.Println(`keycraft - local-first offline password manager
 
@@ -1473,6 +1486,7 @@ Commands:
   change-master    Rotate master password
   backup           Create encrypted backup copy of vault file
   audit            Audit vault for weak/reused/stale credentials
+  version          Print CLI version
   help             Show this help text
 
 Examples:
@@ -1484,5 +1498,6 @@ Examples:
   keycraft delete --id <entry-id>
   keycraft generate --length 32
   keycraft backup
-  keycraft audit --fail-on-issues`)
+  keycraft audit --fail-on-issues
+  keycraft version`)
 }

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -32,6 +32,7 @@ const (
 	keyLength         = 32
 	saltLength        = 16
 	defaultVaultFile  = "vault.json"
+	vaultEnvVar       = "KEYCRAFT_VAULT"
 )
 
 var errEntryNotFound = errors.New("entry not found")
@@ -1184,6 +1185,9 @@ func entryTimestamp(e entry) (time.Time, bool) {
 func resolveVaultPath(pathFlag string) (string, error) {
 	if strings.TrimSpace(pathFlag) != "" {
 		return filepath.Abs(pathFlag)
+	}
+	if envPath := strings.TrimSpace(os.Getenv(vaultEnvVar)); envPath != "" {
+		return filepath.Abs(envPath)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/cmd/keycraft/main_test.go
+++ b/cmd/keycraft/main_test.go
@@ -170,6 +170,16 @@ func TestResolveVaultPathDefaultWhenUnset(t *testing.T) {
 	}
 }
 
+func TestVersionString(t *testing.T) {
+	got := versionString()
+	if !strings.Contains(got, appName) {
+		t.Fatalf("version string missing app name %q: %q", appName, got)
+	}
+	if !strings.Contains(got, appVersion) {
+		t.Fatalf("version string missing app version %q: %q", appVersion, got)
+	}
+}
+
 func assertHasIssue(t *testing.T, issues []auditIssue, kind, entryID string) {
 	t.Helper()
 	for _, issue := range issues {

--- a/cmd/keycraft/main_test.go
+++ b/cmd/keycraft/main_test.go
@@ -130,13 +130,8 @@ func TestResolveVaultPathUsesEnvVar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveVaultPath returned error: %v", err)
 	}
-	want, err := filepath.Abs("./custom-vault.json")
-	if err != nil {
-		t.Fatalf("filepath.Abs returned error: %v", err)
-	}
-	if filepath.Clean(got) != filepath.Clean(want) {
-		t.Fatalf("expected env-based path %q, got %q", want, got)
-	}
+	want := mustAbsPath(t, "./custom-vault.json")
+	assertPathEqual(t, got, want, "expected env-based path")
 }
 
 func TestResolveVaultPathFlagOverridesEnv(t *testing.T) {
@@ -145,13 +140,8 @@ func TestResolveVaultPathFlagOverridesEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveVaultPath returned error: %v", err)
 	}
-	want, err := filepath.Abs("./flag-vault.json")
-	if err != nil {
-		t.Fatalf("filepath.Abs returned error: %v", err)
-	}
-	if filepath.Clean(got) != filepath.Clean(want) {
-		t.Fatalf("expected flag-based path %q, got %q", want, got)
-	}
+	want := mustAbsPath(t, "./flag-vault.json")
+	assertPathEqual(t, got, want, "expected flag-based path")
 }
 
 func TestResolveVaultPathDefaultWhenUnset(t *testing.T) {
@@ -165,9 +155,7 @@ func TestResolveVaultPathDefaultWhenUnset(t *testing.T) {
 		t.Fatalf("os.UserHomeDir returned error: %v", err)
 	}
 	want := filepath.Join(home, ".keycraft", defaultVaultFile)
-	if filepath.Clean(got) != filepath.Clean(want) {
-		t.Fatalf("expected default path %q, got %q", want, got)
-	}
+	assertPathEqual(t, got, want, "expected default path")
 }
 
 func TestVersionString(t *testing.T) {
@@ -177,6 +165,22 @@ func TestVersionString(t *testing.T) {
 	}
 	if !strings.Contains(got, appVersion) {
 		t.Fatalf("version string missing app version %q: %q", appVersion, got)
+	}
+}
+
+func mustAbsPath(t *testing.T, path string) string {
+	t.Helper()
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("filepath.Abs returned error: %v", err)
+	}
+	return absPath
+}
+
+func assertPathEqual(t *testing.T, got, want, msg string) {
+	t.Helper()
+	if filepath.Clean(got) != filepath.Clean(want) {
+		t.Fatalf("%s %q, got %q", msg, want, got)
 	}
 }
 


### PR DESCRIPTION
Closes #1

## Dependencies

<!-- List any PRs that must be merged before this one -->
- _(none needed)_

## What does this PR do?

Adds `version` command support (`keycraft version`, `--version`, `-v`) and introduces `KEYCRAFT_VAULT` as a default vault path when `--vault` is not provided.

## Type of Change

<!-- Check one -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation

## What was changed

### Version output

Added `keycraft version`, `keycraft --version`, and `keycraft -v` flags. Updated help text and added test coverage for version string behavior.

### Vault path default via environment variable

Added `vaultEnvVar = "KEYCRAFT_VAULT"` in `cmd/keycraft/main.go` and updated `resolveVaultPath(...)` with the following precedence:

1. `--vault` flag
2. `KEYCRAFT_VAULT` env var
3. `~/.keycraft/vault.json` (default fallback)

Added tests for env var selection, flag override, and default fallback. Updated README to document `KEYCRAFT_VAULT` and its precedence rules.

## Changelog

- Feature: Added `version` command and `--version`/`-v` flags to print the installed binary version
- Feature: `KEYCRAFT_VAULT` environment variable can now be used to set a default vault path without repeating `--vault` on every command

## How to Test

1. Run `go test ./...`
2. Verify each of `keycraft version`, `--version`, and `-v` print `<app-name> <version>`
3. Set `KEYCRAFT_VAULT=./custom-vault.json` and confirm a command without `--vault` uses the env path
4. Run the same command with `--vault ./flag-vault.json` and confirm it takes precedence over the env var
5. Unset the env var and confirm the fallback is `~/.keycraft/vault.json`

## How QA Should Test

Affected workflows:
- Any command that reads from a vault
- Version/help output

Specific checks:
1. Run `keycraft version`, `keycraft --version`, and `keycraft -v` — all should print the app name and version string
2. Export `KEYCRAFT_VAULT=./custom-vault.json` and run a vault command without `--vault` — confirm the custom path is used
3. Run the same command with `--vault ./other-vault.json` — confirm the flag takes precedence over the env var
4. Unset `KEYCRAFT_VAULT` and run a vault command without `--vault` — confirm it falls back to `~/.keycraft/vault.json`

## Rollback Plan

Revert this PR to restore previous version and vault path behavior.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Note for Reviewer

<!-- Any specific areas you want feedback on? -->