### PR TITLE
feat: add masked password flag and list sort flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,7 @@ keycraft generate --length 20 --count 5
 
 # get masked password
 keycraft get --service <service_name> --masked-password
+
+# list out the service by latest update time or service name
+keycraft list --sort <updated|service>
 ```

--- a/README.md
+++ b/README.md
@@ -81,4 +81,7 @@ keycraft audit --min-length 14 --m  ax-age-days 365 --fail-on-issues
 
 # generate 5 random passwords of length 20
 keycraft generate --length 20 --count 5
+
+# get masked password
+keycraft get --service <service_name> --masked-password
 ```

--- a/Stream_of_Consciousness.txt
+++ b/Stream_of_Consciousness.txt
@@ -26,3 +26,6 @@ so we don't have to make any meaningful changes for each commit, hence committin
 ==> now will add a test for the latest feature that I added, although it's working, ran the test file it's working, so I guess it's fine for now.
 
 ==> I guess I could just add a new feature for all the features that I'm going to add from now on, or maybe not. anyhow I should update the README.md file, that'll make one less commit to go.
+
+# 25-02-26
+==> So today's the deadline, trying to finish this task in this go. 9 more commits to go.

--- a/Stream_of_Consciousness.txt
+++ b/Stream_of_Consciousness.txt
@@ -20,3 +20,9 @@ so we don't have to make any meaningful changes for each commit, hence committin
 
 
 ==> adding another feature which will make 5 commits for this first branch. then left just another commit to go. Just updated the README.md (added an example) file for the latest added features. That makes it 6 commits, now we can move on to the second branch, cascading this one.
+
+==> branched off to a new branch (2nd branch) from the HEAD of the 1st branch. the main file is way too big, guess if I could trim it somehow. anyhow added another feature, it should make up one commit.
+
+==> now will add a test for the latest feature that I added, although it's working, ran the test file it's working, so I guess it's fine for now.
+
+==> I guess I could just add a new feature for all the features that I'm going to add from now on, or maybe not. anyhow I should update the README.md file, that'll make one less commit to go.

--- a/Stream_of_Consciousness.txt
+++ b/Stream_of_Consciousness.txt
@@ -29,3 +29,5 @@ so we don't have to make any meaningful changes for each commit, hence committin
 
 # 25-02-26
 ==> So today's the deadline, trying to finish this task in this go. 9 more commits to go.
+
+==> Added test case for the new sort feature, this should make up one commit, as trying to make the commit as little as possible.

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -334,13 +334,14 @@ func runGet(args []string) error {
 	fs.SetOutput(os.Stderr)
 
 	var vaultPath, id, service, username string
-	var showPassword bool
+	var showPassword, maskedPassword bool
 	fs.StringVar(&vaultPath, "vault", "", "Vault file path")
 	fs.StringVar(&id, "id", "", "Entry ID")
 	fs.StringVar(&service, "service", "", "Service name")
 	fs.StringVar(&username, "username", "", "Username/login")
 	fs.BoolVar(&showPassword, "show-password", false, "Show plaintext password")
-
+	fs.BoolVar(&maskedPassword, "masked-password", false, "Show masked password")
+	
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -370,9 +371,15 @@ func runGet(args []string) error {
 	}
 	e := data.Entries[idx]
 
+	if showPassword && maskedPassword {
+    	return errors.New("use only one of --show-password or --masked-password")
+	}
+
 	password := "<hidden>"
 	if showPassword {
-		password = e.Password
+	    password = e.Password
+	} else if maskedPassword {
+	    password = maskPassword(e.Password)
 	}
 
 	fmt.Printf("ID:        %s\n", e.ID)
@@ -1528,4 +1535,19 @@ Examples:
   keycraft backup
   keycraft audit --fail-on-issues
   keycraft version`)
+}
+
+func maskPassword(input string) string {
+    runes := []rune(input)
+    n := len(runes)
+    if n == 0 {
+        return ""
+    }
+    if n <= 2 {
+        return strings.Repeat("*", n)
+    }
+    if n <= 6 {
+        return string(runes[0]) + strings.Repeat("*", n-2) + string(runes[n-1])
+    }
+    return string(runes[:2]) + strings.Repeat("*", n-4) + string(runes[n-2:])
 }

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -278,10 +278,11 @@ func runList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 
-	var vaultPath, search string
+	var vaultPath, search, sortBy string
 	fs.StringVar(&vaultPath, "vault", "", "Vault file path")
 	fs.StringVar(&search, "search", "", "Case-insensitive search filter")
-
+	fs.StringVar(&sortBy, "sort", "service", "Sort entries by: service|updated")
+	
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -301,6 +302,10 @@ func runList(args []string) error {
 	if err != nil {
 		return err
 	}
+	sortBy = strings.ToLower(strings.TrimSpace(sortBy))
+	if sortBy != "service" && sortBy != "updated" {
+	    return errors.New("--sort must be one of: service, updated")
+	}
 
 	var entries []entry
 	for _, e := range data.Entries {
@@ -315,10 +320,18 @@ func runList(args []string) error {
 	}
 
 	sort.Slice(entries, func(i, j int) bool {
-		if strings.EqualFold(entries[i].Service, entries[j].Service) {
-			return strings.ToLower(entries[i].Username) < strings.ToLower(entries[j].Username)
-		}
-		return strings.ToLower(entries[i].Service) < strings.ToLower(entries[j].Service)
+	    if sortBy == "updated" {
+	        ti := sortableUpdatedTime(entries[i])
+	        tj := sortableUpdatedTime(entries[j])
+	        if !ti.Equal(tj) {
+	            return ti.After(tj) // newest first
+	        }
+	    }
+
+	    if strings.EqualFold(entries[i].Service, entries[j].Service) {
+	        return strings.ToLower(entries[i].Username) < strings.ToLower(entries[j].Username)
+	    }
+	    return strings.ToLower(entries[i].Service) < strings.ToLower(entries[j].Service)
 	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
@@ -327,6 +340,13 @@ func runList(args []string) error {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.ID, e.Service, e.Username, e.UpdatedAt)
 	}
 	return w.Flush()
+}
+
+func sortableUpdatedTime(e entry) time.Time {
+    if ts, ok := entryTimestamp(e); ok {
+        return ts
+    }
+    return time.Time{}
 }
 
 func runGet(args []string) error {

--- a/cmd/keycraft/main_test.go
+++ b/cmd/keycraft/main_test.go
@@ -193,3 +193,18 @@ func assertHasIssue(t *testing.T, issues []auditIssue, kind, entryID string) {
 	}
 	t.Fatalf("expected issue kind=%s id=%s not found", kind, entryID)
 }
+
+func TestMaskPassword(t *testing.T) {
+    if got := maskPassword(""); got != "" {
+        t.Fatalf("expected empty mask, got %q", got)
+    }
+    if got := maskPassword("ab"); got != "**" {
+        t.Fatalf("expected '**', got %q", got)
+    }
+    if got := maskPassword("abcdef"); got != "a****f" {
+        t.Fatalf("unexpected mask: %q", got)
+    }
+    if got := maskPassword("abcdefgh"); got != "ab****gh" {
+        t.Fatalf("unexpected mask: %q", got)
+    }
+}

--- a/cmd/keycraft/main_test.go
+++ b/cmd/keycraft/main_test.go
@@ -208,3 +208,11 @@ func TestMaskPassword(t *testing.T) {
         t.Fatalf("unexpected mask: %q", got)
     }
 }
+
+func TestSortableUpdatedTime(t *testing.T) {
+    e := entry{UpdatedAt: "2026-02-01T00:00:00Z"}
+    ts := sortableUpdatedTime(e)
+    if ts.IsZero() {
+        t.Fatal("expected parsed timestamp")
+    }
+}


### PR DESCRIPTION
Closes #5 

## Dependencies

- #4 

## What does this PR do?

Adds two CLI features and related tests/docs:
- `get --masked-password` for partial password display
- `list --sort <service|updated>` for configurable listing order

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation

## What was changed

- Files changed: `cmd/keycraft/main.go`, `cmd/keycraft/main_test.go`, `README.md`.
- Added `--masked-password` to `get` and masking logic via `maskPassword()`.
- Added exclusivity for `--show-password` and `--masked-password`.
- Added `--sort` to `list` with supported values: `service` (default) and `updated`.
- Added sort-by-updated behavior using parsed timestamps (newest first).
- Added tests for `maskPassword` and sortable updated time parsing.
- Updated README with examples for both new flags.

## Changelog

Feature: Added `get --masked-password` and `list --sort` options.

## How to Test

1. Run `keycraft list --sort service` and `keycraft list --sort updated`; verify order changes as expected.
2. Run `keycraft get --service <service_name> --masked-password`; verify password is partially masked.
3. Run `keycraft get --service <service_name> --show-password --masked-password`; verify it returns a flag conflict error.

## How QA Should Test

Affected workflows:
- Entry retrieval (`get`)
- Entry listing (`list`)

Specific checks:
- `--masked-password` masks output for short and long passwords.
- `--sort updated` places most recently updated entries first.
- Invalid `--sort` values fail with a clear error message.

## Rollback Plan

Revert this PR.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

N/A (CLI-only changes).

## Note for Reviewer

- _(none needed)_