### PR TITLE
feat: add password strength hints and version short flag --rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,8 @@ keycraft get --service <service_name> --masked-password
 
 # list out the service by latest update time or service name
 keycraft list --sort <updated|service>
+
+# get the version of the app
+keycraft version
+keycraft version --short
 ```

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -491,6 +491,7 @@ func runUpdate(args []string) error {
 		if e.Password == "" {
 			return errors.New("--password cannot be empty")
 		}
+		fmt.Fprintf(os.Stderr, "Password strength hint: %s\n", passwordStrengthHint(e.Password))
 	}
 	if urlOpt.set {
 		e.URL = strings.TrimSpace(urlOpt.value)

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -252,6 +252,8 @@ func runAdd(args []string) error {
 		return fmt.Errorf("entry already exists for service=%q username=%q", service, username)
 	}
 
+	fmt.Fprintf(os.Stderr, "Password strength hint: %s\n", passwordStrengthHint(accountPassword))
+
 	now := nowUTC()
 	e := entry{
 		ID:        generateEntryID(),
@@ -1570,4 +1572,18 @@ func maskPassword(input string) string {
         return string(runes[0]) + strings.Repeat("*", n-2) + string(runes[n-1])
     }
     return string(runes[:2]) + strings.Repeat("*", n-4) + string(runes[n-2:])
+}
+
+func passwordStrengthHint(password string) string {
+    length := len([]rune(password))
+    classes := passwordClassCount(password)
+
+    switch {
+    case length >= 16 && classes >= 3:
+        return "strong"
+    case length >= 12 && classes >= 2:
+        return "ok"
+    default:
+        return "weak"
+    }
 }

--- a/cmd/keycraft/main.go
+++ b/cmd/keycraft/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	command := os.Args[1]
 	if command == "version" || command == "-v" || command == "--version" {
-		fmt.Println(versionString())
+		fmt.Println(runVersion(os.Args[2:]))
 		return
 	}
 	if command == "help" || command == "-h" || command == "--help" {
@@ -138,7 +138,7 @@ func main() {
 	case "audit":
 		err = runAudit(os.Args[2:])
 	case "version":
-		fmt.Println(versionString())
+		err = runVersion(os.Args[2:])
 		return
 	default:
 		printUsage()
@@ -1587,4 +1587,26 @@ func passwordStrengthHint(password string) string {
     default:
         return "weak"
     }
+}
+
+func runVersion(args []string) error {
+    fs := flag.NewFlagSet("version", flag.ContinueOnError)
+    fs.SetOutput(os.Stderr)
+
+    var short bool
+    fs.BoolVar(&short, "short", false, "Print version number only")
+
+    if err := fs.Parse(args); err != nil {
+        return err
+    }
+    if fs.NArg() != 0 {
+        return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+    }
+
+    if short {
+        fmt.Println(appVersion)
+        return nil
+    }
+    fmt.Println(versionString())
+    return nil
 }


### PR DESCRIPTION
Closes #7 

## Dependencies

- _(none needed)_

## What does this PR do?

Adds two CLI improvements and updates docs:
- password strength hint output during password set/update
- `version --short` for version-only output

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation

## What was changed

- Files in scope: `cmd/keycraft/main.go`, `README.md`.
- Added `passwordStrengthHint()` and prints hint in `runAdd`.
- Added hint in `runUpdate` when `--password` is provided.
- Added `runVersion` command handler with `--short`.
- Updated top-level version dispatch (`version`, `-v`, `--version`) to use `runVersion`.
- Added README examples for `keycraft version` and `keycraft version --short`.

## Changelog

Feature: Added password strength hints and `version --short`.

## How to Test

1. Run `keycraft add ...` and confirm a password strength hint is printed.
2. Run `keycraft update --id <entry-id> --password -` and confirm a password strength hint is printed.
3. Run `keycraft version` and `keycraft version --short` and verify output formats differ as expected.

## How QA Should Test

Affected workflows:
- Add entry
- Update entry password
- Version command output

Specific checks:
- Hint values are one of `weak`, `ok`, or `strong`.
- `--short` prints only the version number.
- `-v` and `--version` still work and accept `--short`.

## Rollback Plan

Revert this PR.

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

N/A (CLI-only changes).

## Note for Reviewer

- _(none needed)_
